### PR TITLE
Update patches verified with T540p and USB vendor ID removal

### DIFF
--- a/xx40_xx50_patches_v7.txt
+++ b/xx40_xx50_patches_v7.txt
@@ -28,8 +28,12 @@
 # LenovoWmaPolicyDxe | Whitelist removal | T440p W540 T540
 # https://github.com/thrimbor/thinkpad-uefi-patches/
 79E0EDD7-9D1D-4F41-AE1A-F896169E5216 10 P:0bc841390b0f8468010000:0bc841390be96901000000      
+# bypass the PCI vendor ID check
 79E0EDD7-9D1D-4F41-AE1A-F896169E5216 10 P:41390b7517:41390b7500  
+# bypass the PCI subsys ID check
 79E0EDD7-9D1D-4F41-AE1A-F896169E5216 10 P:41394b04741b:41394b04eb1b  
+# bypass the USB vendor ID check
+79E0EDD7-9D1D-4F41-AE1A-F896169E5216 10 P:41390B0F8469010000:41390B48E969010000  
 
 
 # LenovoWmaPolicyDxe | Whitelist removal | W541 | \x


### PR DESCRIPTION
Had a problem using this with my T540p. Diagnosed the issue down to having TWO loops run of the checker, one in PCI-mode and one in USB-mode. The PCI-mode check was patched but the USB-mode check was not patched (possibly missed with the first line I didn't attach a descriptive comment to - that didn't match bytes in my module version).

To do this, I broke the module apart with Ghidra and discovered the unpatched USB check. The original patch did enable advanced BIOS settings page, but it only decreased the number of "unauthorized network adapter" messages from 2 to 1. I traced down that the type of message it was displaying (showing only a VID/PID, and no subsys) was actually faulting for the USB VID, not the PCI VID/subsys. So I simply patched out that check, the same way was the PCI check was patched (jmp, not jz), and voila, it finally let me boot.

(edit to add: not entirely sure, but what's seen as the "VID" is likely the VID+PID combo (4 bytes), not just VID (2 bytes). Don't mind me, just patching together what I know here!)